### PR TITLE
Create design-asset.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/design-asset.md
+++ b/.github/ISSUE_TEMPLATE/design-asset.md
@@ -1,0 +1,29 @@
+---
+name: Design Asset
+about: Encompasses requests that need a designer to create an asset for a larger initiative
+title: ''
+labels: 'Type: Design Asset :jigsaw:'
+assignees: ''
+
+---
+
+## What is this asset supporting?
+Describe what this asset is supporting and where it will be seen. For example: "_This will be the hero image for this (link here) blog article_"
+
+## Why?
+Please clearly outline the problem we are looking to solve or the need we are looking to fill with this deliverable.
+
+## Who are we creating this for?
+Who will be interacting with this deliverable, where will they see it, and what do we want them to do as a result?
+
+## Content
+Please provide a link to the content that will be used for this deliverable.
+
+## Size & Format
+Any specific required size (e.g. 8.5x11in) or aspect ratio (e.g. 16:9)? And any format requirements (PDF, PNG, JPG, etc.)?
+
+## Ideas
+Do you have any ideas about key visual themes to explore? Feel free to link out to any visuals or sketches you have done.
+
+## Other
+Please list any other notes or requirements you have for this project


### PR DESCRIPTION
I would like to add an issue template so community teams like writing can request design assets without us having to go through outside platforms that I can't invite everyone to.

## Description
I would like to add an issue template so community teams like writing can request design assets without us having to go through outside platforms that I can't invite everyone to. An issue template was created in our issues template list. This issue template would be for requesting design assets.

## Affected Dependencies
List any dependencies that are required for this change.
This is new and unattached to anything outside of our issues templates.

## How has this been tested?
- This has not been tested. It is an issues template in markdown.

## Checklist
- [ ] I have followed the [Contribution Guidelines](https://github.com/OpenMined/.github/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/OpenMined/.github/blob/master/CODE_OF_CONDUCT.md)
- [ ] I have commented my code following the [OpenMined Styleguide](https://github.com/OpenMined/.github/blob/master/STYLEGUIDE.md)
- [ ] I have labeled this PR with the relevant [Type labels](https://github.com/OpenMined/.github/labels?q=Type%3A)
- [ ] My changes are covered by tests
